### PR TITLE
More mods to refactor PR

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -13,6 +13,5 @@ API Reference
    lyse.figure_manager
    lyse.filebox
    lyse.routines
-   lyse.tempfile2clipboard
    lyse.utils
    lyse.__main__

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -22,7 +22,7 @@ import warnings
 
 import labscript_utils.h5_lock, h5py
 import pandas
-from numpy import array, where
+import numpy as np
 
 from .__version__ import __version__
 
@@ -482,7 +482,7 @@ class Run(object):
         if raw_data:
             data = trace[()]
         else:
-            data = array(trace['t'],dtype=float),array(trace['values'],dtype=float)  
+            data = np.array(trace['t'],dtype=float), np.array(trace['values'],dtype=float)  
         
         return data
 
@@ -504,7 +504,7 @@ class Run(object):
         name=name.encode()
         if name not in self.h5_file['data']['waits']['label']:
             raise Exception('The wait \'%s\' does not exist'%name.decode())
-        name_index, =where(self.h5_file['data']['waits']['label']==name)[0]
+        name_index, = np.where(self.h5_file['data']['waits']['label']==name)[0]
         return self.h5_file['data']['waits'][name_index]
 
     @open_file('r')
@@ -542,7 +542,7 @@ class Run(object):
             raise Exception('The result group \'%s\' does not exist'%group)
         if name not in self.h5_file['results'][group]:
             raise Exception('The result array \'%s\' does not exist'%name)
-        return array(self.h5_file['results'][group][name])
+        return np.array(self.h5_file['results'][group][name])
 
     @open_file('r')            
     def get_result(self, group, name):
@@ -866,7 +866,7 @@ class Run(object):
             raise Exception('File does not contain any images with label \'%s\''%label)
         if image not in self.h5_file['images'][orientation][label]:
             raise Exception('Image \'%s\' not found in file'%image)
-        return array(self.h5_file['images'][orientation][label][image])
+        return np.array(self.h5_file['images'][orientation][label][image])
 
     @open_file('r')    
     def get_images(self, orientation, label, *images):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -38,7 +38,8 @@ import lyse.utils
 
 # Import this way so LYSE_DIR is exposed when someone does import lyse or from lyse import *
 from lyse.utils import LYSE_DIR
-from lyse.utils.worker import spinning_top, _updated_data, register_plot_class, delay_results_return
+from lyse.utils.worker import register_plot_class, delay_results_return
+
 if len(sys.argv) > 1:
     warnings.warn("Running standalone single-shot lyse scripts is deprecated. "
                   "If you need this feature, let the developers know so it is not removed.",
@@ -610,6 +611,9 @@ class Run(object):
             PermissionError: A `PermissionError` is raised if an attribute with
                 name `name` already exists but `overwrite` is set to `False`.
         """
+        # lazy import here so they get updated values from analysis subprocess
+        from lyse.utils.worker import spinning_top, _updated_data
+
         if not group:
             if self.group is None:
                 msg = """Cannot save result; no default group set. Either
@@ -631,9 +635,8 @@ class Run(object):
                 )
             raise PermissionError(dedent(msg))
         set_attributes(self.h5_file[group], {name: value})
-            
+        
         if spinning_top:
-            global _updated_data
             if self.h5_path not in _updated_data:
                 _updated_data[self.h5_path] = {}
             if group.startswith('results'):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -40,6 +40,21 @@ import lyse.utils
 from lyse.utils import LYSE_DIR
 from lyse.utils.worker import register_plot_class, delay_results_return
 
+__all__ = [
+    # interacting with lyse internals
+    'LYSE_DIR',
+    'register_plot_class',
+    'delay_results_return',
+    # lyse analysis API objects
+    'path',  # needed so old star imports know to pull `path` from the lazy loader here
+    'routine_storage',
+    'data',
+    'globals_diff',
+    'open_file',
+    'Run',
+    'Sequence',
+]
+
 if len(sys.argv) > 1:
     warnings.warn("Running standalone single-shot lyse scripts is deprecated. "
                   "If you need this feature, let the developers know so it is not removed.",

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -61,6 +61,15 @@ if len(sys.argv) > 1:
                   FutureWarning)
     path = sys.argv[1]
 
+if 'sphinx' in sys.modules:
+    # building docs, define path with docstring here so docs knows it's present
+    path = None
+    """Links to :attr:`lyse.utils.worker.path` which contains hdf5 filepath to be analysed.
+    
+    Automatically populated by the lyse GUI.
+    Can be passed as a command line argument, but this behavior is deprecated.
+    """
+
 # lazy import so we catch updated path from analysis subprocess
 def __getattr__(name):
     if name == 'path':
@@ -79,6 +88,14 @@ class _RoutineStorage(object):
     these cases."""
 
 routine_storage = _RoutineStorage()
+"""An empty object that analysis routines can store data in.
+
+It will persist from one run of an analysis routine to the next when the routine
+is being run from within lyse. No attempt is made to store data to disk,
+so if the routine is run multiple times from the command line instead of
+from lyse, or the lyse analysis subprocess is restarted, data will not be
+retained. An alternate method should be used to store data if desired in
+these cases."""
 
 
 def data(filepath=None, host='localhost', port=lyse.utils.LYSE_PORT, timeout=5, n_sequences=None, filter_kwargs=None):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -39,6 +39,11 @@ import lyse.utils
 # Import this way so LYSE_DIR is exposed when someone does import lyse or from lyse import *
 from lyse.utils import LYSE_DIR
 from lyse.utils.worker import spinning_top, _updated_data, register_plot_class, delay_results_return
+if len(sys.argv) > 1:
+    warnings.warn("Running standalone single-shot lyse scripts is deprecated. "
+                  "If you need this feature, let the developers know so it is not removed.",
+                  FutureWarning)
+    path = sys.argv[1]
 
 # lazy import so we catch updated path from analysis subprocess
 def __getattr__(name):

--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -40,13 +40,10 @@ import lyse.utils
 from lyse.utils import LYSE_DIR
 from lyse.utils.worker import spinning_top, _updated_data, register_plot_class, delay_results_return
 
-# note: path is injected into the script namespace by AnalysisWorker at runtime
+# lazy import so we catch updated path from analysis subprocess
 def __getattr__(name):
     if name == 'path':
         from lyse.utils.worker import path
-        warnings.warn("'path' is now automatically injected into the script namespace. "
-                      "Importing it from 'lyse.path' will be deprecated.",
-                      FutureWarning)
         return path
     else:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/lyse/analysis_subprocess.py
+++ b/lyse/analysis_subprocess.py
@@ -310,11 +310,9 @@ class AnalysisWorker(object):
         # Reset the routine module's namespace:
         self.routine_module.__dict__.clear()
         self.routine_module.__dict__.update(self.routine_module_clean_dict)
-        # inject path into script namespace
-        self.routine_module.__dict__['path'] = path
 
         # global variables used to communicate between analysis processes and GUI functions
-        lyse.utils.worker.path = path  # for backwards compat with scripts that use lyse.path
+        lyse.utils.worker.path = path
         lyse.utils.worker.plots = self.plots
         lyse.utils.worker.Plot = Plot
         lyse.utils.worker._updated_data = {}

--- a/lyse/utils/__init__.py
+++ b/lyse/utils/__init__.py
@@ -20,12 +20,24 @@ from pathlib import Path
 from labscript_utils.labconfig import LabConfig
 
 LYSE_DIR = Path(__file__).resolve().parent.parent
+"""Variable that stores lyse installation directory"""
 
 # Open up the lab config
 LABCONFIG = LabConfig()
+""":external+labscript-utils:class:`~labscript_utils.labconfig.LabConfig` instance"""
 
 # get port that lyse is using for communication
 try:
     LYSE_PORT = int(LABCONFIG.get('ports', 'lyse'))
+    """Port that lyse listens on for inter-module communications.
+    
+    Read from labconfig, defaults to 42519 if config doesn't specify.
+    """
+    # document here so local docs builds get the string
 except Exception:
     LYSE_PORT = 42519
+    """Port that lyse listens on for inter-module communications.
+    
+    Read from labconfig, defaults to 42519 if config doesn't specify.
+    """
+    # document here so RTD gets the string

--- a/lyse/utils/worker.py
+++ b/lyse/utils/worker.py
@@ -20,23 +20,26 @@ import threading
 from labscript_utils import dedent
 
 
-# If running stand-alone, and not from within lyse, the below two variables
-# will be as follows. Otherwise lyse will override them with spinning_top =
-# True and path <name of hdf5 file being analysed>:
 spinning_top = False
+"""Variable to tell lyse API if running from within lyse GUI"""
 path = None
-# data to be sent back to the lyse GUI if running within lyse
+"""Path to hdf5 being analysed.
+
+If running stand-alone, not from within the lyse GUI, default is None.
+Within lyse GUI, updated automatically to the correct path.
+"""
 _updated_data = {}
-# dictionary of plot id's to classes to use for Plot object
+"""Data to be sent back to the lyse GUI if running within lyse"""
 _plot_classes = {}
-# A fake Plot object to subclass if we are not running in the GUI
+"""Dictionary of plot id's to classes to use for Plot object"""
 Plot=object
-# An empty dictionary of plots (overwritten by the analysis worker if running within lyse)
+"""A fake Plot object to subclass if we are not running in the GUI"""
 plots = {}
-# A threading.Event to delay the 
+"""An empty dictionary of plots (overwritten by the analysis worker if running within lyse)"""
 delay_event = threading.Event()
-# a flag to determine whether we should wait for the delay event
+"""A threading.Event to signal a delay"""
 _delay_flag = False
+"""Flag to determine whether we should wait for the delay event"""
 
 
 utils_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Reworks `path` magic to be exposed as `lyse.path` so that when we drop star imports it is more obvious where the magic thing is coming from.

Also adds backwards compatibility for headless lyse workflow, and warning that we intend to drop it in the future.

Finally, fixes `spinning_top` and `_updated_data` communication globals so that they actually work. Before this, they didn't update at worker execution, so data wouldn't save back to the lyse dataframe. (Hazard of testing changes by re-running the same analysis)

@ispielma Feel free to let me know if there is anything you don't like. I feel much better about this approach, and the testing of the changes is apparently more thorough too.